### PR TITLE
display last_sync date in debug mode

### DIFF
--- a/check_sync.py
+++ b/check_sync.py
@@ -80,6 +80,9 @@ def check_running_tasks(clear):
                     if repo_status['last_sync']['result'] == 'warning':
                         incomplete_sync = 1
                         print helpers.WARNING + "Incomplete: " + helpers.ENDC + repo_status['name']
+                    else:
+                        msg = repo_status['name'] + " - last_sync: " + repo_status['last_sync']['ended_at']
+                        helpers.log_msg(msg, 'DEBUG')
 
     # If we have detected incomplete sync tasks, ask the user if they want to export anyway.
     # This isn't fatal, but *MAY* lead to inconsistent repositories on the dieconnected sat.


### PR DESCRIPTION
In debug mode it displays last_sync date ("ended_at" value) for completed syncs:
```
Checking for incomplete (stopped) yum sync tasks...
DEBUG: Red Hat Enterprise Linux 7 Server RPMs x86_64 7Server - last sync: 2017-09-21 07:01:51 UTC
DEBUG: Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64 - last sync: 2017-12-21 08:57:44 UTC
DEBUG: Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.4 - last sync: 2017-09-21 07:19:35 UTC
No incomplete syncs detected
```